### PR TITLE
Prevent empty tooltip flash

### DIFF
--- a/src/map-renderer.ts
+++ b/src/map-renderer.ts
@@ -528,6 +528,10 @@ export function createMapRenderer(config: MapRendererOptions): Deck<MapViewType[
 
     const updateTooltip = async (point: MapPoint, x: number, y: number) => {
         const thisUpdateId = ++tooltipUpdateId;
+
+        // Hide tooltip before clearing to prevent empty tooltip flash
+        tooltip.removeClass('visible');
+
         tooltip.textContent = '';
         const renderPromises: Promise<void>[] = [];
 


### PR DESCRIPTION
Hide tooltip before clearing content to ensure the tooltip is never visible with stale/empty content.